### PR TITLE
fix: update nodes, edges, and network ref on update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,18 @@ const Graph = ({
       edges.current.add(edgesAdded);
       edges.current.update(edgesChanged);
     }
+
+    if ((nodesChange || edgesChange) && getNetwork) {
+      getNetwork(network.current);
+    }
+
+    if (nodesChange && getNodes) {
+      getNodes(nodes.current);
+    }
+
+    if (edgesChange && getEdges) {
+      getEdges(edges.current);
+    }
   }, [data]);
 
   useEffect(() => {


### PR DESCRIPTION
When the nodes/edges change, ref of network is not updated in the parent